### PR TITLE
fix: fix link url of secret document

### DIFF
--- a/app/components/pipeline-secret-settings/template.hbs
+++ b/app/components/pipeline-secret-settings/template.hbs
@@ -1,7 +1,7 @@
 {{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
 <h3>
   Secrets
-  <a href="http://docs.screwdriver.cd/user-guide/configuration/secrets/">
+  <a href="http://docs.screwdriver.cd/user-guide/configuration/secrets">
     <i class="fa fa-question-circle" title="More information"></i>
   </a>
 </h3>


### PR DESCRIPTION
The current guide link of secrets is wrong, it returns 404. This PR will fix to correct link.
Before: http://docs.screwdriver.cd/user-guide/configuration/secrets/
After: http://docs.screwdriver.cd/user-guide/configuration/secrets